### PR TITLE
Replace all std::string_view return values

### DIFF
--- a/include/bactria/bactria.hpp
+++ b/include/bactria/bactria.hpp
@@ -16,10 +16,6 @@
 #ifndef BACTRIA_BACTRIA_HPP
 #define BACTRIA_BACTRIA_HPP
 
-#include <memory>
-#include <string>
-#include <string_view>
-
 #include <bactria/event.hpp>
 #include <bactria/phase.hpp>
 #include <bactria/region.hpp>

--- a/include/bactria/event.hpp
+++ b/include/bactria/event.hpp
@@ -17,7 +17,7 @@
 #define BACTRIA_EVENT_HPP
 
 #include <string>
-#include <string_view>
+#include <utility>
 
 /**
  * The bactria user API
@@ -38,8 +38,8 @@ namespace bactria
              * \param event_name The event name as it should appear on the
              *                   output file or the visualizer.
              */
-            event(const std::string& event_name)
-            : name{event_name}
+            event(std::string event_name)
+            : name{std::move(event_name)}
             {}
 
             virtual ~event() = default;
@@ -47,9 +47,9 @@ namespace bactria
             /**
              * Returns the event name.
              */
-            virtual auto get_name() const -> std::string_view
+            virtual auto get_name() const noexcept -> const std::string&
             {
-                return std::string_view(name); 
+                return name; 
             }
 
 

--- a/include/bactria/phase.hpp
+++ b/include/bactria/phase.hpp
@@ -17,7 +17,7 @@
 #define BACTRIA_PHASE_HPP
 
 #include <string>
-#include <string_view>
+#include <utility>
 
 namespace bactria
 {
@@ -35,16 +35,16 @@ namespace bactria
              * \param phase_name The phase name as it should appear on the
              *                   output file or visualizer.
              */
-            phase(const std::string& phase_name)
-            : name{phase_name}
+            phase(std::string phase_name)
+            : name{std::move(phase_name)}
             {}
 
             /**
              * Returns the phase name.
              */
-            auto get_name() const -> std::string_view
+            auto get_name() const noexcept -> const std::string&
             {
-                return std::string_view{name};
+                return name;
             }
 
         private:

--- a/include/bactria/region.hpp
+++ b/include/bactria/region.hpp
@@ -18,7 +18,7 @@
 
 #include <memory>
 #include <string>
-#include <string_view>
+#include <utility>
 
 #include <bactria/event.hpp>
 #include <bactria/phase.hpp>
@@ -80,11 +80,11 @@ namespace bactria
              *          that p is a non-owning pointer; it is expected that
              *          p's lifetime exceeds the region's lifetime.
              */
-            region(const std::string& region_name,
+            region(std::string region_name,
                    region_type region_t = generic_region_type{}, 
                    bool auto_recording = true,
                    const phase* p = nullptr)
-            : name{region_name}
+            : name{std::move(region_name)}
             , type{region_t}
             , recording{auto_recording}
             , handle{plugin::handle::make_handle(name)}
@@ -159,9 +159,9 @@ namespace bactria
             /**
              * Returns the region name.
              */
-            auto get_name() const -> std::string_view
+            auto get_name() const noexcept -> const std::string&
             {
-                return std::string_view(name);
+                return name;
             }
 
             /**


### PR DESCRIPTION
  * Replace all string_view return values with const string&
  * get_name getters are now declared noexcept
  * Removed unnecessary includes from bactria.hpp

Fixes #1.