### PR TITLE
Fix badge links

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # bactria - Broadly Applicable C++ Tracing and Instrumentation API
 
 [![Language](https://img.shields.io/badge/-C++14-5E97D0?logo=C%2B%2B&logoColor=white&style=for-the-badge)](https://isocpp.org/)
-[![Platforms](https://img.shields.io/badge/platform-linux%20|%20windows%20|%20mac-lightgrey?style=for-the-badge)](https://github.com/alpaka-group/alpaka)
-[![License](https://img.shields.io/github/license/alpaka-group/bactria?color=003399&style=for-the-badge)](https://www.mozilla.org/en-US/MPL/2.0/)
+[![Platforms](https://img.shields.io/badge/platform-linux%20|%20windows%20|%20mac-lightgrey?style=for-the-badge)](https://github.com/alpaka-group/bactria)
+[![License](https://img.shields.io/github/license/alpaka-group/bactria?color=003399&style=for-the-badge)](https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12)
 
 ## About this project
 


### PR DESCRIPTION
The badges for "Platforms" and "Licence" were pointing to the wrong websites.